### PR TITLE
Update GolangSimple.cmake

### DIFF
--- a/cmake/modules/GolangSimple.cmake
+++ b/cmake/modules/GolangSimple.cmake
@@ -9,7 +9,7 @@ function(ADD_GO_INSTALLABLE_PROGRAM NAME MAIN_SRC)
   get_filename_component(MAIN_SRC_ABS ${MAIN_SRC} ABSOLUTE)
   add_custom_target(${NAME})
   add_custom_command(TARGET ${NAME}
-                    COMMAND env GOPATH=${GOPATH} go build 
+                    COMMAND env GO111MODULE=off GOPATH=${GOPATH} go build 
                     -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}"
                     ${CMAKE_GO_FLAGS} ${MAIN_SRC}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}


### PR DESCRIPTION
Disable go modules for preventing 'cannot find module for path' error in modern golang versions